### PR TITLE
dockerize gw-sim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN ls / && pwd
 
 WORKDIR /code
 
-EXPOSE 80/tcp
+EXPOSE 3001/tcp
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apk add git bash
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-RUN ls / && pwd
-
 WORKDIR /code
 
 EXPOSE 3001/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:19.4.0-alpine3.16
+
+RUN apk add git bash
+
+COPY ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+RUN ls / && pwd
+
+WORKDIR /code
+
+EXPOSE 80/tcp
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,31 @@ Dies ist ein Simulator für das Browser Game https://www.gigrawars.de/
 Aktuell wird das projekt gratis in der google cloud gehosted:
 
 https://gw-sim-361609.ey.r.appspot.com/
+
+## lokale Umgebung mit docker-env & gw-sim
+Wer lokal kein Node installieren möchte, kann die enthaltene Docker-Umgebung nutzen.
+
+Lokale Docker-Umgebung kann über `gw-sim` gestartet werden. Der erste Start baut einen geeigneten Container.
+```
+./gw-sim start
+```
+
+Nach dem ersten Start müssen alle notwendigen Abhängigkeiten installiert werden.
+```
+./gw-sim install
+```
+
+Um den Node-Prozess zu starten können wir folgenden Befehl über `gw-sim` ausführen.
+```
+./gw-sim local
+```
+Simulator ist anschließend im Browser erreichbar über http://localhost:3001.
+
+Weitere Befehle:
+* `gw-sim start` - startet die lokale Umgebung
+* `gw-sim stop` - stoppt die lokale Umgebung
+* `gw-sim exec [CMD]` - führt `[CMD]` im Container aus
+* `gw-sim install` - installiert alle notwendigen Abhängikeiten via `yarn`
+* `gw-sim build` - alias für `gw-sim exec npm run build`
+* `gw-sim watch` - alias für `gw-sim exec npm run watch`
+* `gw-sim local` - alias für `gw-sim exec npm run local`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+volumes:
+    elastic:
+    mysql:
+
+
+services:
+
+    ############
+    ### Node ###
+    ############
+
+    node:
+        build: .
+        restart: always
+        volumes:
+            - ./:/code
+        ports:
+            - "3001:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,3 @@
-volumes:
-    elastic:
-    mysql:
-
-
 services:
 
     ############

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "${@}" = "" ]]; then
+    tail -f /dev/null
+    exit 0;
+fi
+
+exec ${@}

--- a/gw-sim
+++ b/gw-sim
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+FUNCTIONS=(
+    "build"
+    "watch"
+    "local"
+    "start"
+    "stop"
+    "exec"
+    "install"
+)
+
+COMPOSE_FLAGS="-f docker-compose.yml"
+COMPOSE_CONTAINER="node"
+
+build() {
+    exec npm run build
+}
+
+watch() {
+    exec npm run watch
+}
+
+local() {
+    exec npm run local
+}
+
+start () {
+    docker compose $COMPOSE_FLAGS up -d $COMPOSE_CONTAINER
+}
+
+stop () {
+    docker compose $COMPOSE_FLAGS down
+}
+
+exec() {
+    docker compose $COMPOSE_FLAGS exec $COMPOSE_CONTAINER ${@};
+}
+
+install () {
+    exec yarn
+}
+
+for fnc in ${FUNCTIONS[@]}; do
+    if [[ "$fnc" = "$1" ]]; then
+        $fnc ${@:2};
+    fi
+done


### PR DESCRIPTION
Dieser PR stellt den gesamten Simulator als Docker-Umgebung zur Verfügung.

* `gw-sim` hinzugefügt, für häufig genutzt bash-befehle
* `Dockerfile` und `entrypoint.sh` hinzugefügt, für node-container mit relevanten Abhängigkeiten
* `docker-compose.yml` hinzugefügt, docker-compose Konfiguration
* `README.md` angepasst